### PR TITLE
add inclusão projeto tradução HEXO

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ projetos | tecnologias
 [Estrutura de dados - "exemplos de referência"](https://github.com/danilosilvadev/EstudosEstruturadeDados/tree/master/src) | JAVA
 [Material design e outros - "referência"](https://github.com/danilosilvadev/MaterialDesignANDROID) | Android
 [Pure CSS Eric Cartman](https://github.com/alinebastos/css-eric-cartman) | CSS3
+[Tradução - Hexo gerador de site estático](https://github.com/lucianobarauna/dochexo) | HTML, JS, CSS, Node, Pug, Stylus
 
 ## intermediario
 


### PR DESCRIPTION
Adicionando link de apoio e tradução da documentação do gerador de site estático HEXO feito em node.js